### PR TITLE
updated snapshots to account for whitespace and blank lines.

### DIFF
--- a/src/components/__snapshots__/AccessKeyForm.test.js.snap
+++ b/src/components/__snapshots__/AccessKeyForm.test.js.snap
@@ -184,7 +184,7 @@ exports[`Access Key Login Form renders and matches snapshot 1`] = `
           value="Log In"
         />
       </form>
-
+      
     </div>
   </div>
 </div>

--- a/src/components/__snapshots__/TrustedLoginSettings.test.js.snap
+++ b/src/components/__snapshots__/TrustedLoginSettings.test.js.snap
@@ -177,8 +177,8 @@ exports[`TrustedLoginSettings renders & matches snapshot, with on-boarding NOT c
                             >
                               <li
                                 class="
-              highlightOption highlight
-              false
+              highlightOption highlight 
+              false 
               false option
             "
                               >
@@ -186,8 +186,8 @@ exports[`TrustedLoginSettings renders & matches snapshot, with on-boarding NOT c
                               </li>
                               <li
                                 class="
-
-              false
+               
+              false 
               false option
             "
                               >


### PR DESCRIPTION
The purpose of this PR is to fix the failing Jest Tests. Currently these test are failing because of a blank line and extra whitespace in the snapshot. This fixes that.

## Acceptance Criteria
- Blank lines and extra whitespace in the current snapshots shouldn't throw an error during `yarn test`#141 

## Testing
1. Checkout `fix-jest-test`
2. Run `yarn test`
3. Profit