### PR TITLE
Changing teams now adjusts the team settings for that team.

### DIFF
--- a/src/components/teams/EditTeam.js
+++ b/src/components/teams/EditTeam.js
@@ -1,5 +1,5 @@
 import { useView } from "../../hooks/useView";
-import { useRef, useState, useMemo } from "react";
+import { useRef, useState, useEffect, useMemo } from "react";
 import { __ } from "@wordpress/i18n";
 
 import { InputField, SelectField, SelectFieldArea } from "./fields";
@@ -11,19 +11,19 @@ import TitleDescriptionLink from "../TitleDescriptionLink";
 import { useSettings } from "../../hooks/useSettings";
 
 //HelpDesk select
-export const HelpDeskSelect = ({ defaultValue, options = null }) => {
+export const HelpDeskSelect = ({ value, onChange, options = null }) => {
   const { getEnabledHelpDeskOptions } = useSettings();
   const helpDeskOptions = useMemo(() => {
     return options ? options : getEnabledHelpDeskOptions();
   }, [options, getEnabledHelpDeskOptions]);
+
   return (
     <SelectField
       name={teamFields.helpdesk.id}
       id={teamFields.helpdesk.id}
       label={teamFields.helpdesk.label}
-      defaultValue={
-        defaultValue ? defaultValue : teamFields.helpdesk.defaultValue
-      }>
+      value={value}
+      onChange={onChange}>
       {helpDeskOptions.length ? (
         <>
           <option>{__("Select a Help Desk", "trustedlogin-vendor")}</option>
@@ -46,6 +46,20 @@ const EditTeam = ({ team = null, onClickSave, formTitle = "Update Team" }) => {
   const formRef = useRef();
   //useState for approved_roles, because that works.
   const [approved_roles, set_approved_roles] = useState(team?.approved_roles);
+  // Declare local state for account_id, public_key, and private_key
+  const [account_id, setAccount_id] = useState(team?.account_id);
+  const [public_key, setPublic_key] = useState(team?.public_key);
+  const [private_key, setPrivate_key] = useState(team?.private_key);
+  const [selectedHelpDesk, setSelectedHelpDesk] = useState(team?.helpdesk?.[0] ?? teamFields?.helpdesk?.defaultValue ?? '');
+
+  // Update local state when team changes
+  useEffect(() => {
+    setAccount_id(team?.account_id);
+    setPublic_key(team?.public_key);
+    setPrivate_key(team?.private_key);
+    set_approved_roles(team?.approved_roles);
+    setSelectedHelpDesk(team?.helpdesk?.[0] ?? teamFields?.helpdesk?.defaultValue ?? '');
+  }, [team]);
 
   //When form is submitted, collect the data and pass it to onClickSave
   const handleSave = (e) => {
@@ -102,28 +116,31 @@ const EditTeam = ({ team = null, onClickSave, formTitle = "Update Team" }) => {
           <div className="flex flex-col py-6 space-y-6 sm:space-y-0 sm:space-x-12 sm:flex-row">
             <div className="flex flex-col space-y-6 sm:flex-1">
               <InputField
-                type="text"
-                name={teamFields.account_id.id}
-                id={teamFields.account_id.id}
-                label={teamFields.account_id.label}
-                defaultValue={team?.account_id}
-                required={true}
+                  type="text"
+                  name={teamFields.account_id.id}
+                  id={teamFields.account_id.id}
+                  label={teamFields.account_id.label}
+                  value={account_id}
+                  onChange={(e) => setAccount_id(e.target.value)}
+                  required={true}
               />
               <InputField
-                type="text"
-                name={teamFields.public_key.id}
-                id={teamFields.public_key.id}
-                label={teamFields.public_key.label}
-                defaultValue={team?.public_key}
-                required={true}
+                  type="text"
+                  name={teamFields.public_key.id}
+                  id={teamFields.public_key.id}
+                  label={teamFields.public_key.label}
+                  value={public_key}
+                  onChange={(e) => setPublic_key(e.target.value)}
+                  required={true}
               />
               <InputField
-                type="text"
-                name={teamFields.private_key.id}
-                id={teamFields.private_key.id}
-                label={teamFields.private_key.label}
-                defaultValue={team?.private_key}
-                required={true}
+                  type="text"
+                  name={teamFields.private_key.id}
+                  id={teamFields.private_key.id}
+                  label={teamFields.private_key.label}
+                  value={private_key}
+                  onChange={(e) => setPrivate_key(e.target.value)}
+                  required={true}
               />
             </div>
             <div className="flex flex-col space-y-6 sm:flex-1">
@@ -137,9 +154,8 @@ const EditTeam = ({ team = null, onClickSave, formTitle = "Update Team" }) => {
                 />
               </SelectFieldArea>
               <HelpDeskSelect
-                defaultValue={
-                    team?.helpdesk?.[0] ?? teamFields?.helpdesk?.defaultValue ?? ''
-                }
+                  value={selectedHelpDesk}
+                  onChange={(e) => setSelectedHelpDesk(e.target.value)}
               />
             </div>
           </div>

--- a/src/components/teams/fields.js
+++ b/src/components/teams/fields.js
@@ -19,38 +19,34 @@ export const InputFieldArea = ({ id, label, children }) => (
     <div className="mt-2 relative rounded-lg">{children}</div>
   </div>
 );
-export const InputField = ({
-  id,
-  name,
-  label,
-  type = "text",
-  defaultValue = null,
-  required = false,
-}) => {
-  return (
-    <InputFieldArea name={name} id={id} label={label}>
-      <input
-        type={type}
-        name={name}
-        id={id}
-        required={required}
-        defaultValue={defaultValue}
-        className="block w-full pl-4 pr-10 py-2.5 sm:text-sm border border-gray-300 rounded-lg focus:outline-none focus:border-sky-500 focus:ring-1 ring-offset-2 focus:ring-sky-500"
-      />
-    </InputFieldArea>
-  );
+
+export const InputField = ({ id, name, label, type = "text", value = "", onChange, required = false, }) => {
+    return (
+        <InputFieldArea name={name} id={id} label={label}>
+            <input
+                type={type}
+                name={name}
+                id={id}
+                required={required}
+                value={value}
+                onChange={onChange}
+                className="block w-full pl-4 pr-10 py-2.5 sm:text-sm border border-gray-300 rounded-lg focus:outline-none focus:border-sky-500 focus:ring-1 ring-offset-2 focus:ring-sky-500"
+            />
+        </InputFieldArea>
+    );
 };
 
-export const SelectField = ({ id, name, label, children, defaultValue }) => {
-  return (
-    <SelectFieldArea label={label} id={id}>
-      <select
-        id={id}
-        name={name}
-        defaultValue={defaultValue}
-        className="bg-white block w-full pl-3 pr-8 py-2.5 sm:text-sm border border-gray-300 rounded-lg focus:outline-none focus:border-sky-500 focus:ring-1 ring-offset-2 focus:ring-sky-500">
-        {children}
-      </select>
-    </SelectFieldArea>
-  );
+export const SelectField = ({ id, name, label, children, value, onChange }) => {
+    return (
+        <SelectFieldArea label={label} id={id}>
+            <select
+                id={id}
+                name={name}
+                value={value}
+                onChange={onChange}
+                className="bg-white block w-full pl-3 pr-8 py-2.5 sm:text-sm border border-gray-300 rounded-lg focus:outline-none focus:border-sky-500 focus:ring-1 ring-offset-2 focus:ring-sky-500">
+                {children}
+            </select>
+        </SelectFieldArea>
+    );
 };


### PR DESCRIPTION
The purpose of this PR is to address issue #143 i.e. ensure that changing teams using the status menu changes the teams settings on the edit team form.

## Acceptance Criteria
- Changing the team should update the settings to display the settings for that team.
- The fields should load sensible defaults when creating a new team.
- The fields on other views should continue to work as expected.

## Testing
1. Checkout `143-team-switcher-settings`
2. Run `yarn build`
3. Go to the settings screen and ensure that you have 2 teams entered.
4. Using the status menu switch between the 2 team settings and verify they change as expected.

## Video
https://www.loom.com/share/a67e476465be4167af5ce2ceb9b6db2e