### PR TITLE
145 enable toggle transition

### DIFF
--- a/src/components/__snapshots__/AccessKeyForm.test.js.snap
+++ b/src/components/__snapshots__/AccessKeyForm.test.js.snap
@@ -184,7 +184,7 @@ exports[`Access Key Login Form renders and matches snapshot 1`] = `
           value="Log In"
         />
       </form>
-
+      
     </div>
   </div>
 </div>

--- a/src/components/__snapshots__/TrustedLoginSettings.test.js.snap
+++ b/src/components/__snapshots__/TrustedLoginSettings.test.js.snap
@@ -177,8 +177,8 @@ exports[`TrustedLoginSettings renders & matches snapshot, with on-boarding NOT c
                             >
                               <li
                                 class="
-              highlightOption highlight
-              false
+              highlightOption highlight 
+              false 
               false option
             "
                               >
@@ -186,8 +186,8 @@ exports[`TrustedLoginSettings renders & matches snapshot, with on-boarding NOT c
                               </li>
                               <li
                                 class="
-
-              false
+               
+              false 
               false option
             "
                               >

--- a/src/components/integrations/Integration.js
+++ b/src/components/integrations/Integration.js
@@ -34,7 +34,7 @@ const Integration = ({ Icon, name, description, id, toggleOpenState }) => {
 
   const spanClassName = useMemo(() => {
     let className = isEnabled ? "translate-x-5" : "translate-x-0";
-    return `${className} translate-x-5 inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200`;
+    return `${className} inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition-transform ease-in-out duration-200`;
   }, [isEnabled]);
 
   //When button is clicked:

--- a/src/trustedlogin-dist.css
+++ b/src/trustedlogin-dist.css
@@ -1872,6 +1872,14 @@ select {
   transition-duration: 150ms;
 }
 
+.transition-transform {
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
 .duration-200 {
   transition-duration: 200ms;
 }


### PR DESCRIPTION
The purpose of this PR is to address issue #145  i.e. ensure that clicking the toggle on the integrations page will animate left/right instead of fading in & out.

## Acceptance Criteria
- Turning on/off a help desk integration should animate left/right instead of fading in/out.

## Testing
1. Checkout `145-enable-toggle-transition`
2. Run `yarn build`
3. Go to the Help Desks screen and click the available help desks on/off.

## Video
https://www.loom.com/share/c3e6259d5ff6470ea88ffff6a5f1a879