### PR TITLE
144 override default form styles

### DIFF
--- a/src/components/__snapshots__/AccessKeyForm.test.js.snap
+++ b/src/components/__snapshots__/AccessKeyForm.test.js.snap
@@ -184,7 +184,7 @@ exports[`Access Key Login Form renders and matches snapshot 1`] = `
           value="Log In"
         />
       </form>
-
+      
     </div>
   </div>
 </div>

--- a/src/components/__snapshots__/TrustedLoginSettings.test.js.snap
+++ b/src/components/__snapshots__/TrustedLoginSettings.test.js.snap
@@ -177,8 +177,8 @@ exports[`TrustedLoginSettings renders & matches snapshot, with on-boarding NOT c
                             >
                               <li
                                 class="
-              highlightOption highlight
-              false
+              highlightOption highlight 
+              false 
               false option
             "
                               >
@@ -186,8 +186,8 @@ exports[`TrustedLoginSettings renders & matches snapshot, with on-boarding NOT c
                               </li>
                               <li
                                 class="
-
-              false
+               
+              false 
               false option
             "
                               >

--- a/src/components/teams/TeamsList.js
+++ b/src/components/teams/TeamsList.js
@@ -113,7 +113,7 @@ const TeamsList = () => {
                     <input
                       id="search"
                       name="search"
-                      className="block w-full h-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg leading-5 bg-white placeholder-gray-500 focus:outline-none focus:ring-2 ring-offset-2 focus:ring-sky-500 sm:text-sm sm:py-2"
+                      className="block w-full h-full !pl-10 !pr-3 !py-3 !border !border-gray-300 !rounded-lg leading-5 !bg-white placeholder-gray-500 focus:outline-none focus:ring-2 ring-offset-2 focus:ring-sky-500 sm:text-sm sm:py-2"
                       placeholder={__('Search…', 'trustedlogin-vendor')}
                       type="search"
                     />

--- a/src/trustedlogin-dist.css
+++ b/src/trustedlogin-dist.css
@@ -1346,12 +1346,20 @@ select {
   border-radius: 0.375rem;
 }
 
+.\!rounded-lg {
+  border-radius: 0.5rem !important;
+}
+
 .border {
   border-width: 1px;
 }
 
 .border-2 {
   border-width: 2px;
+}
+
+.\!border {
+  border-width: 1px !important;
 }
 
 .border-b {
@@ -1388,6 +1396,11 @@ select {
 
 .border-transparent {
   border-color: transparent;
+}
+
+.\!border-gray-300 {
+  --tw-border-opacity: 1 !important;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity)) !important;
 }
 
 .bg-black {
@@ -1437,6 +1450,11 @@ select {
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
+.\!bg-white {
+  --tw-bg-opacity: 1 !important;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity)) !important;
 }
 
 .p-1 {
@@ -1552,6 +1570,11 @@ select {
   padding-bottom: 2rem;
 }
 
+.\!py-3 {
+  padding-top: 0.75rem !important;
+  padding-bottom: 0.75rem !important;
+}
+
 .pb-0 {
   padding-bottom: 0px;
 }
@@ -1630,6 +1653,14 @@ select {
 
 .pt-8 {
   padding-top: 2rem;
+}
+
+.\!pl-10 {
+  padding-left: 2.5rem !important;
+}
+
+.\!pr-3 {
+  padding-right: 0.75rem !important;
 }
 
 .text-left {
@@ -1868,6 +1899,14 @@ select {
   transition-property: color, background-color, border-color, fill, stroke, -webkit-text-decoration-color;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, -webkit-text-decoration-color;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-transform {
+  transition-property: -webkit-transform;
+  transition-property: transform;
+  transition-property: transform, -webkit-transform;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }


### PR DESCRIPTION
The purpose of this PR is to address issue #144  i.e. ensure that the form css isn't overwritten by the default WordPress form styles.

## Acceptance Criteria
- The search form on the top of the teams list should look as expected.

## Testing
1. Checkout `144-override-default-form-styles`
2. Run `yarn build`
3. Go to the Teams screen and ensure that the search form looks as expected.

## Video
https://www.loom.com/share/0628e8bbfa9346af9e4798956c61a5fc